### PR TITLE
fix: wrap App in BrowserRouter for proper SPA routing

### DIFF
--- a/billirae-frontend/src/main.tsx
+++ b/billirae-frontend/src/main.tsx
@@ -1,10 +1,13 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App'
+import { BrowserRouter } from 'react-router-dom';
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-)
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>,
+);


### PR DESCRIPTION
Diese Änderung behebt das Problem, dass direkte Seitenaufrufe (z. B. /register) in der Live-Version mit einem 404-Fehler enden. Durch das Einfügen von <BrowserRouter> wird clientseitiges Routing korrekt unterstützt.
